### PR TITLE
Add TypeScript definitions for JavaScript API

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -90,7 +90,9 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Install clink
-        run: dotnet tool install --global clink
+        # Newer clink releases enable strict missing-reference validation by default,
+        # which is incompatible with the client's current link creation API.
+        run: dotnet tool install --global clink --version 2.2.2
 
       - name: Verify clink installation
         run: clink --version

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-12T04:18:35.315Z for PR creation at branch issue-22-baf17a59d199 for issue https://github.com/link-foundation/links-client/issues/22

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-12T04:18:35.315Z for PR creation at branch issue-22-baf17a59d199 for issue https://github.com/link-foundation/links-client/issues/22

--- a/js/.changeset/bright-links-types.md
+++ b/js/.changeset/bright-links-types.md
@@ -1,0 +1,5 @@
+---
+"@link-foundation/links-client": minor
+---
+
+Add TypeScript declarations for the JavaScript package's public API.

--- a/js/README.md
+++ b/js/README.md
@@ -17,6 +17,9 @@ dotnet tool install --global clink
 npm install @link-foundation/links-client
 ```
 
+The package includes TypeScript declarations for all public exports, so no separate
+`@types` package is required.
+
 Or use GitHub directly:
 
 ```bash

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Unlicense",
       "devDependencies": {
         "@changesets/cli": "^2.29.7",
-        "test-anywhere": "^0.7.0"
+        "test-anywhere": "^0.7.0",
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2110,6 +2111,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {

--- a/js/package.json
+++ b/js/package.json
@@ -3,9 +3,11 @@
   "version": "1.1.0",
   "description": "Node.js client library for link-cli (Links Theory database)",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "type": "module",
   "scripts": {
-    "test": "node --test --test-concurrency=1 tests/",
+    "test": "npm run test:types && node --test --test-concurrency=1 tests/",
+    "test:types": "tsc --noEmit -p tests/types/tsconfig.json",
     "changeset": "changeset",
     "changeset:version": "node ../scripts/changeset-version.mjs",
     "changeset:publish": "changeset publish",
@@ -32,6 +34,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
-    "test-anywhere": "^0.7.0"
+    "test-anywhere": "^0.7.0",
+    "typescript": "^5.9.2"
   }
 }

--- a/js/src/api/menu-config-routes.js
+++ b/js/src/api/menu-config-routes.js
@@ -239,3 +239,5 @@ export function createMenuConfigLinkDBRoutes() {
 
   return router;
 }
+
+export default createMenuConfigLinkDBRoutes;

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -1,0 +1,188 @@
+export interface Link {
+  id: number;
+  source: number;
+  target: number;
+}
+
+export interface QueryOptions {
+  before?: boolean;
+  changes?: boolean;
+  after?: boolean;
+  trace?: boolean;
+}
+
+export interface MenuItem {
+  label?: string;
+  icon?: string;
+  to?: string;
+  items?: MenuItem[];
+  [key: string]: unknown;
+}
+
+export interface StoredMenuItem extends MenuItem {
+  _linkId: number;
+  _itemId: number;
+  _parentId?: number;
+  items?: StoredMenuItem[];
+}
+
+export interface UserData {
+  username?: string;
+  email?: string;
+  profile?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface StoredUser extends UserData {
+  userId: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface TokenData {
+  apiKey?: string;
+  permissions?: string[];
+  expiresAt?: string;
+  [key: string]: unknown;
+}
+
+export interface StoredToken extends TokenData {
+  tokenId: string;
+  userId: string;
+  createdAt: string;
+}
+
+export interface PasswordData {
+  hash: string;
+  salt: string;
+  algorithm?: string;
+  iterations?: number;
+  [key: string]: unknown;
+}
+
+export interface StoredPassword extends PasswordData {
+  passwordId: string;
+  userId: string;
+  createdAt: string;
+}
+
+export interface StorageStatistics {
+  totalLinks: number;
+  users: { links: number; files: number };
+  tokens: { links: number; files: number };
+  passwords: { files: number };
+}
+
+export class LinkDBService {
+  constructor(dbPath?: string);
+  dbPath: string;
+  nextId: number;
+  executeQuery(query: string, options?: QueryOptions): Promise<string>;
+  parseLinks(output: string): Link[];
+  createLink(source: number, target: number): Promise<Link>;
+  readAllLinks(): Promise<Link[]>;
+  readLink(id: number): Promise<Link | null>;
+  updateLink(id: number, newSource: number, newTarget: number): Promise<Link>;
+  deleteLink(id: number): Promise<boolean>;
+  storeMenuItem(menuItem: MenuItem): Promise<number>;
+  getAllMenuItems(): Promise<Link[]>;
+  deleteMenuItem(linkId: number): Promise<boolean>;
+  clearDatabase(): Promise<boolean>;
+}
+
+export class MenuStorageService {
+  constructor();
+  linkDB: LinkDBService;
+  ensureDataDirectory(): Promise<void>;
+  generateItemId(item: MenuItem): number;
+  saveItemData(itemId: number, item: MenuItem): Promise<void>;
+  loadItemData(itemId: number): Promise<MenuItem | null>;
+  storeMenuItem(item: MenuItem, parentId?: number): Promise<number>;
+  storeMenuStructure(menuItems: MenuItem[], parentId?: number): Promise<number[]>;
+  getMenuStructure(parentId?: number): Promise<StoredMenuItem[]>;
+  getAllMenuItems(): Promise<StoredMenuItem[]>;
+  deleteMenuItem(itemId: number): Promise<boolean>;
+  clearAllMenus(): Promise<boolean>;
+  getStatistics(): Promise<{ totalLinks: number; totalFiles: number; rootItems: number }>;
+}
+
+export class AuthStorageService {
+  constructor();
+  linkDB: LinkDBService;
+  ensureDataDirectories(): Promise<void>;
+  generateId(content: object, prefix?: string): string;
+  idToNumber(id: string): number;
+  saveData(dir: string, id: string, data: object): Promise<void>;
+  loadData(dir: string, id: string): Promise<Record<string, unknown> | null>;
+  createUser(userData: UserData): Promise<StoredUser>;
+  getUser(userId: string): Promise<StoredUser | null>;
+  getAllUsers(): Promise<StoredUser[]>;
+  updateUser(userId: string, updates: Partial<UserData>): Promise<StoredUser>;
+  deleteUser(userId: string): Promise<boolean>;
+  createToken(userId: string, tokenData: TokenData): Promise<StoredToken>;
+  getToken(tokenId: string): Promise<StoredToken | null>;
+  getUserTokens(userId: string): Promise<StoredToken[]>;
+  deleteToken(tokenId: string): Promise<boolean>;
+  setPassword(userId: string, passwordData: PasswordData): Promise<StoredPassword>;
+  getUserPassword(userId: string): Promise<StoredPassword | null>;
+  getUserPasswords(userId: string): Promise<StoredPassword[]>;
+  deletePassword(passwordId: string): Promise<boolean>;
+  getStatistics(): Promise<StorageStatistics>;
+  clearAllAuthData(): Promise<boolean>;
+  findUserByUsername(username: string): Promise<StoredUser | null>;
+  findUserByEmail(email: string): Promise<StoredUser | null>;
+  findTokenByApiKey(apiKey: string): Promise<StoredToken | null>;
+}
+
+export interface LinksConstants {
+  Continue: symbol;
+  Break: symbol;
+  Any: 0;
+}
+
+export type LinkRestriction = readonly number[];
+export type LinkSubstitution = readonly [number, number] | readonly [number, number, number];
+export type LinkHandler = (link: Link) => symbol | void | Promise<symbol | void>;
+export interface LinkChange { before: Link | null; after: Link | null }
+export type LinkChangeHandler = (change: LinkChange) => void | Promise<void>;
+
+export class ILinks {
+  constructor(dbPath?: string | null);
+  db: LinkDBService;
+  constants: LinksConstants;
+  getConstants(): LinksConstants;
+  count(restriction?: LinkRestriction | null): Promise<number>;
+  each(restriction?: LinkRestriction | null, handler?: LinkHandler | null): Promise<symbol>;
+  create(substitution: LinkSubstitution, handler?: LinkChangeHandler | null): Promise<number>;
+  update(restriction: LinkRestriction, substitution: LinkSubstitution, handler?: LinkChangeHandler | null): Promise<number>;
+  delete(restriction: LinkRestriction, handler?: LinkChangeHandler | null): Promise<number>;
+}
+
+export type NestedLinkValue = number | NestedLinkArray | NestedLinkObject;
+export type NestedLinkArray = NestedLinkValue[];
+export type NestedLinkObject = { [reference: string]: NestedLinkArray };
+
+export class RecursiveLinks {
+  constructor(dbPath?: string | null);
+  links: ILinks;
+  idCounter: number;
+  getLinks(): ILinks;
+  createFromNestedArray(nestedArray: NestedLinkArray[]): Promise<number[]>;
+  createFromNestedObject(nestedObject: NestedLinkObject): Promise<Record<string, number>>;
+  readAsNestedArray(restriction?: LinkRestriction | null): Promise<number[][]>;
+  toLinksNotation(input: NestedLinkArray | NestedLinkObject | number): string;
+  parseLinksNotation(notation: string): NestedLinkArray;
+}
+
+export interface Logger {
+  debug(contextOrMessage: unknown, message?: string): void;
+  info(contextOrMessage: unknown, message?: string): void;
+  warn(contextOrMessage: unknown, message?: string): void;
+  error(contextOrMessage: unknown, message?: string): void;
+}
+
+export const logger: Logger;
+
+/** Express router factory. The return type is structural to avoid requiring @types/express. */
+export function menuConfigRoutes(): { use: (...args: unknown[]) => unknown };
+export const authDataRoutes: { use: (...args: unknown[]) => unknown };

--- a/js/tests/types-package.test.js
+++ b/js/tests/types-package.test.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const packageJsonUrl = new URL('../package.json', import.meta.url);
+
+test('package publishes a TypeScript declaration entry point', async () => {
+  const packageJson = JSON.parse(await readFile(packageJsonUrl, 'utf8'));
+
+  assert.equal(packageJson.types, 'src/index.d.ts');
+  await assert.doesNotReject(() => readFile(new URL('../src/index.d.ts', import.meta.url), 'utf8'));
+});

--- a/js/tests/types/consumer.ts
+++ b/js/tests/types/consumer.ts
@@ -1,0 +1,27 @@
+import {
+  AuthStorageService,
+  ILinks,
+  LinkDBService,
+  MenuStorageService,
+  RecursiveLinks,
+  type Link,
+  type MenuItem,
+} from '../../src/index.js';
+
+const db = new LinkDBService('/tmp/example.links');
+const created: Promise<Link> = db.createLink(1, 2);
+const found: Promise<Link | null> = db.readLink(1);
+
+const menu: MenuItem[] = [{ label: 'Home', to: '/', items: [{ label: 'Child' }] }];
+const menuStorage = new MenuStorageService();
+const menuIds: Promise<number[]> = menuStorage.storeMenuStructure(menu);
+
+const auth = new AuthStorageService();
+const userId: Promise<string> = auth.createUser({ username: 'alice' }).then(user => user.userId);
+
+const links = new ILinks();
+const count: Promise<number> = links.count([0, 1, 2]);
+const recursive = new RecursiveLinks();
+const notation: string = recursive.toLinksNotation([[1, 2], [3, 4]]);
+
+void [created, found, menuIds, userId, count, notation];

--- a/js/tests/types/tsconfig.json
+++ b/js/tests/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["consumer.ts"]
+}


### PR DESCRIPTION
## Summary

Adds official TypeScript declarations for the JavaScript package's complete public API.

- declares links, query options, menu/auth data, services, `ILinks`, recursive links, logger, and route exports
- advertises `src/index.d.ts` through the package `types` field
- runs a strict TypeScript consumer fixture as part of `npm test`
- verifies the declaration entry point is published
- adds the missing default export for the menu route factory so the existing package entry point imports successfully
- pins JavaScript CI to `clink` 2.2.2, the last release compatible with the client's current implicit reference-creation behavior
- includes a minor changeset and documents bundled typings

## Reproduction

Before this change, importing `@link-foundation/links-client` from TypeScript provided no declarations because the package had neither a `types` field nor a declaration file. The package regression test reproduces that absence by asserting both.

The previously failing CI run installed `clink` 2.5.0, whose strict missing-reference validation rejects the client's existing creation queries. The same suite passes with the compatible 2.2.2 release.

## Verification

- `cd js && npm test` — 73/73 tests pass with `clink` 2.2.2
- `cd js && npm run test:types` — strict consumer fixture passes
- `cd js && npm pack --dry-run --json` — confirms `src/index.d.ts` is included
- `node scripts/validate-changeset.mjs` — changeset valid

Fixes #22
